### PR TITLE
Refreshes the link to project 14

### DIFF
--- a/532_submissions.html
+++ b/532_submissions.html
@@ -156,7 +156,7 @@
 
                 <p> 
                     <b>Methods to exploit structured sparsity</b> <br>
-	            <a href="532_submission_1/Lab14.html">LAB 14</a> 
+	            <a href="https://github.com/scottsievert/ece532_finalproj/raw/master/lab.zip">LAB 14</a> 
                 </p>     
 
                 <p> 


### PR DESCRIPTION
We submitted a HTML file with a link, and this PR adds that link to the page (and not a link to the HTML file which includes the link).

(tested with rawgit.com and it downloads the correct file)
